### PR TITLE
Fixed crashed caused when plugin is registered in background

### DIFF
--- a/android/src/main/kotlin/com/hoanglm/flutteryoutubeview/FlutterYoutubeViewPlugin.kt
+++ b/android/src/main/kotlin/com/hoanglm/flutteryoutubeview/FlutterYoutubeViewPlugin.kt
@@ -69,7 +69,9 @@ class FlutterYoutubeViewPlugin(registrar: Registrar): Application.ActivityLifecy
         @JvmStatic
         fun registerWith(registrar: Registrar) {
             val plugin = FlutterYoutubeViewPlugin(registrar)
-            registrar.activity().application.registerActivityLifecycleCallbacks(plugin)
+            if (registrar.activity() != null) {
+                registrar.activity().application.registerActivityLifecycleCallbacks(plugin)
+            }
             registrar
                 .platformViewRegistry()
                 .registerViewFactory(

--- a/android/src/main/kotlin/com/hoanglm/flutteryoutubeview/FlutterYoutubeViewPlugin.kt
+++ b/android/src/main/kotlin/com/hoanglm/flutteryoutubeview/FlutterYoutubeViewPlugin.kt
@@ -12,7 +12,11 @@ class FlutterYoutubeViewPlugin(registrar: Registrar): Application.ActivityLifecy
     private val registrarActivityHashCode: Int
 
     init {
-        registrarActivityHashCode = registrar.activity().hashCode()
+        if (registrar.activity() != null) {
+            registrarActivityHashCode = registrar.activity().hashCode()
+        } else {
+            registrarActivityHashCode = 0
+        }
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {


### PR DESCRIPTION
I'm using flutter_youtube_view in a project that deals with push notification messages.
In a background environment, other plugins need to be registered in order to work in such environment, so we are registering flutter_youtube_view too.

But activities don't exist in background, therefore flutter_youtube_view is crashing trying to access a null activity.

Best regards.