### PR TITLE
Change PlaybackRate to accept double or enum

### DIFF
--- a/lib/src/flutter_youtube_view_controller.dart
+++ b/lib/src/flutter_youtube_view_controller.dart
@@ -42,26 +42,23 @@ class FlutterYoutubeViewController {
     await _channel.invokeMethod('seekTo', time);
   }
 
-  Future<void> setPlaybackRate(PlaybackRate rate) async {
-    double rateValue;
+  Future<void> setPlaybackRate({PlaybackRate rate, double rateValue = 1}) async {
+    assert(rate != null || rateValue != null);
     switch (rate) {
-      case(PlaybackRate.RATE_0_25):
+      case PlaybackRate.RATE_0_25:
         rateValue = 0.25;
         break;
-      case(PlaybackRate.RATE_0_5):
+      case PlaybackRate.RATE_0_5:
         rateValue = 0.5;
         break;
-      case(PlaybackRate.RATE_1):
+      case PlaybackRate.RATE_1:
         rateValue = 1;
         break;
-      case(PlaybackRate.RATE_1_5):
+      case PlaybackRate.RATE_1_5:
         rateValue = 1.5;
         break;
-      case(PlaybackRate.RATE_2):
+      case PlaybackRate.RATE_2:
         rateValue = 2.0;
-        break;
-      default:
-        rateValue = 1.0;
         break;
     }
     await _channel.invokeMethod('setPlaybackRate', rateValue);


### PR DESCRIPTION
Currently, only the enum is acceptable, but on the Platform interface, is possible to send a double as PlaybackRate.
So, this PR enables it to send double or enum, if both, enum will be used. If none, it goes back to normal (RATE_1).

ps.: removed the parenthesis from "switch" so AndroidStudio can recognize all enum types.
ps2.: changed the version to 1.1.9 already and changed the docs as well.