### PR TITLE
Change PlaybackRate to accept double or enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Currently apps need to opt-in for the UIViews embedding preview on iOS by adding
 - setVolume() only Android
 - mute()
 - unMute()
-- setPlaybackRate(PlaybackRate rate)
+- setPlaybackRate(rate: PlaybackRate.RATE_1) or setPlaybackRate(rateValue: 1.0) 
 ### PLAYER callback
 ```dart
   void onReady();

--- a/example/lib/YoutubeCustomWidget.dart
+++ b/example/lib/YoutubeCustomWidget.dart
@@ -91,7 +91,7 @@ class _MyAppState extends State<YoutubeCustomWidget>
   void _changePlaybackRate(PlaybackRate playbackRate) {
     setState(() {
       _playbackRate = playbackRate;
-      _controller.setPlaybackRate(playbackRate);
+      _controller.setPlaybackRate(rate: playbackRate);
     });
   }
 

--- a/lib/src/flutter_youtube_view_controller.dart
+++ b/lib/src/flutter_youtube_view_controller.dart
@@ -42,8 +42,9 @@ class FlutterYoutubeViewController {
     await _channel.invokeMethod('seekTo', time);
   }
 
-  Future<void> setPlaybackRate(PlaybackRate rate) async {
-    double rateValue;
+  /// Change player PlaybackRate based on [PlaybackRate] or [rateValue]. If both params, [PlaybackRate] will be used.
+  Future<void> setPlaybackRate({PlaybackRate rate, double rateValue = 1.0}) async {
+    assert(rate != null || rateValue != null);
     switch (rate) {
       case(PlaybackRate.RATE_0_25):
         rateValue = 0.25;
@@ -61,7 +62,7 @@ class FlutterYoutubeViewController {
         rateValue = 2.0;
         break;
       default:
-        rateValue = 1.0;
+        rateValue = rateValue;
         break;
     }
     await _channel.invokeMethod('setPlaybackRate', rateValue);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_youtube_view
 description: A new Flutter plugin.
-version: 1.1.9
+version: 1.1.10
 homepage: https://github.com/hoanglm4/flutter_youtube
 
 environment:


### PR DESCRIPTION
Currently, only the enum is acceptable, but on the Platform interface, is possible to send a double as PlaybackRate.
So, this PR enables it to send double or enum, if both, enum will be used. If none, it goes back to normal (RATE_1).

ps.: removed the parenthesis from "switch" so AndroidStudio can recognize all enum types.
ps2.: changed the version to 1.1.9, updated the example and the docs as well.