### PR TITLE
Fix user iteraction

### DIFF
--- a/ios/Classes/FlutterYoutubeView.swift
+++ b/ios/Classes/FlutterYoutubeView.swift
@@ -149,6 +149,12 @@ class FlutterYoutubeView: NSObject, FlutterPlatformView {
             ]
         }
         self.player = YTSwiftyPlayer(playerVars: playerVars)
+        
+        if (!showUI) {
+            // disable user iteraction if not showing UI
+            self.player.scrollView.subviews.forEach { $0.isUserInteractionEnabled = false }
+        }
+        
         self.player.autoplay = autoPlay
         self.playerView.addSubview(self.player)
         switch scaleMode {


### PR DESCRIPTION
If showUi enabled, block user iteraction with the player.
It was working on Android player, but not on iOS player. This PR fixes that.