### PR TITLE
Fixing "Type 'VideoEmbedParameter' has no member 'showInfo'" error on IOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+Fixed:
+IOS: "Type 'VideoEmbedParameter' has no member 'showInfo'" error 
 ## 2.0.4
 https://github.com/hoanglm4/flutter_youtube_view/issues/73
 ## 2.0.3

--- a/example/lib/YoutubeCustomWidget.dart
+++ b/example/lib/YoutubeCustomWidget.dart
@@ -12,14 +12,14 @@ class _MyAppState extends State<YoutubeCustomWidget>
   double _videoDuration = 0.0;
   double _currentVideoSecond = 0.0;
   String _playerState = "";
-  FlutterYoutubeViewController _controller;
+  late FlutterYoutubeViewController _controller;
   YoutubeScaleMode _mode = YoutubeScaleMode.none;
   PlaybackRate _playbackRate = PlaybackRate.RATE_1;
   bool _isMuted = false;
 
   @override
   void onCurrentSecond(double second) {
-   // print("onCurrentSecond second = $second");
+    // print("onCurrentSecond second = $second");
     _currentVideoSecond = second;
   }
 
@@ -70,16 +70,18 @@ class _MyAppState extends State<YoutubeCustomWidget>
     _controller.setVolume(volumePercent);
   }
 
-  void _changeScaleMode(YoutubeScaleMode mode) {
+  void _changeScaleMode(YoutubeScaleMode? mode) {
+    assert(mode != null);
     setState(() {
-        _mode = mode;
-        _controller.changeScaleMode(mode);
+      _mode = mode!;
+      _controller.changeScaleMode(mode);
     });
   }
 
-  void _changeVolumeMode(bool isMuted) {
+  void _changeVolumeMode(bool? isMuted) {
+    assert(isMuted != null);
     setState(() {
-      _isMuted = isMuted;
+      _isMuted = isMuted!;
       if (isMuted) {
         _controller.setMute();
       } else {
@@ -88,9 +90,10 @@ class _MyAppState extends State<YoutubeCustomWidget>
     });
   }
 
-  void _changePlaybackRate(PlaybackRate playbackRate) {
+  void _changePlaybackRate(PlaybackRate? playbackRate) {
+    assert(playbackRate != null);
     setState(() {
-      _playbackRate = playbackRate;
+      _playbackRate = playbackRate!;
       _controller.setPlaybackRate(rate: playbackRate);
     });
   }
@@ -98,30 +101,28 @@ class _MyAppState extends State<YoutubeCustomWidget>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Custom UI')
-        ),
+        appBar: AppBar(title: const Text('Custom UI')),
         body: Stack(
           children: <Widget>[
             Container(
                 child: FlutterYoutubeView(
-                  scaleMode: _mode,
-                  onViewCreated: _onYoutubeCreated,
-                  listener: this,
-                  params: YoutubeParam(
-                      videoId: 'gcj2RUWQZ60',
-                      showUI: false,
-                      startSeconds: 0.0,
-                      autoPlay: true,
-                  ),
-                )),
+              scaleMode: _mode,
+              onViewCreated: _onYoutubeCreated,
+              listener: this,
+              params: YoutubeParam(
+                videoId: 'gcj2RUWQZ60',
+                showUI: false,
+                startSeconds: 0.0,
+                autoPlay: true,
+              ),
+            )),
             Column(
               children: <Widget>[
                 Text(
                   'Current state: $_playerState',
                   style: TextStyle(color: Colors.blue),
                 ),
-                RaisedButton(
+                TextButton(
                   onPressed: _loadOrCueVideo,
                   child: Text('Click reload video'),
                 ),
@@ -139,15 +140,15 @@ class _MyAppState extends State<YoutubeCustomWidget>
     return new Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: <Widget>[
-        RaisedButton(
+        TextButton(
           onPressed: _play,
           child: Text('Play'),
         ),
-        RaisedButton(
+        TextButton(
           onPressed: _pause,
           child: Text('Pause'),
         ),
-        RaisedButton(
+        TextButton(
           onPressed: () {
             _seekTo(20.0);
           },
@@ -271,5 +272,3 @@ class _MyAppState extends State<YoutubeCustomWidget>
     );
   }
 }
-
-

--- a/example/lib/YoutubeDefaultWidget.dart
+++ b/example/lib/YoutubeDefaultWidget.dart
@@ -10,7 +10,7 @@ class _MyAppState extends State<YoutubeDefaultWidget>
     implements YouTubePlayerListener {
   double _currentVideoSecond = 0.0;
   String _playerState = "";
-  FlutterYoutubeViewController _controller;
+  late FlutterYoutubeViewController _controller;
 
   @override
   void onCurrentSecond(double second) {
@@ -74,7 +74,7 @@ class _MyAppState extends State<YoutubeDefaultWidget>
                   'Current state: $_playerState',
                   style: TextStyle(color: Colors.blue),
                 ),
-                RaisedButton(
+                TextButton(
                   onPressed: _loadOrCueVideo,
                   child: Text('Click reload video'),
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'YoutubeCustomWidget.dart';
 import 'YoutubeDefaultWidget.dart';
 
@@ -7,13 +8,10 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      routes: <String, WidgetBuilder>{
-        '/custom': (BuildContext context) => new YoutubeCustomWidget(),
-        '/non_custom': (BuildContext context) => new YoutubeDefaultWidget(),
-      },
-      home: HomeScreen()
-    );
+    return MaterialApp(routes: <String, WidgetBuilder>{
+      '/custom': (BuildContext context) => new YoutubeCustomWidget(),
+      '/non_custom': (BuildContext context) => new YoutubeDefaultWidget(),
+    }, home: HomeScreen());
   }
 }
 
@@ -24,13 +22,13 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(title: Text('Youtube player')),
       body: Center(
         child: Column(children: <Widget>[
-          RaisedButton(
+          TextButton(
             onPressed: () {
               Navigator.of(context).pushNamed('/custom');
             },
             child: Text('Open customize player'),
           ),
-          RaisedButton(
+          TextButton(
             onPressed: () {
               Navigator.of(context).pushNamed('/non_custom');
             },

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the flutter_youtube_view plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=3.2.2 <4.0.0"
 
 dependencies:
   flutter:
@@ -11,7 +11,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.6
 
 dev_dependencies:
   flutter_test:

--- a/ios/Classes/FlutterYoutubeView.swift
+++ b/ios/Classes/FlutterYoutubeView.swift
@@ -132,7 +132,6 @@ class FlutterYoutubeView: NSObject, FlutterPlatformView {
                 VideoEmbedParameter.videoID(videoId),
                 VideoEmbedParameter.loopVideo(false),
                 VideoEmbedParameter.showRelatedVideo(false),
-                VideoEmbedParameter.showInfo(true),
                 VideoEmbedParameter.autoplay(autoPlay),
                 VideoEmbedParameter.registerStartTimeAt(Int(startSeconds))
             ]
@@ -142,7 +141,6 @@ class FlutterYoutubeView: NSObject, FlutterPlatformView {
                 VideoEmbedParameter.videoID(videoId),
                 VideoEmbedParameter.loopVideo(false),
                 VideoEmbedParameter.showRelatedVideo(false),
-                VideoEmbedParameter.showInfo(false),
                 VideoEmbedParameter.showControls(VideoControlAppearance.hidden),
                 VideoEmbedParameter.autoplay(autoPlay),
                 VideoEmbedParameter.registerStartTimeAt(Int(startSeconds))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.4
 homepage: https://github.com/hoanglm4/flutter_youtube
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.2.2 <4.0.0"
   flutter: ">=1.12.0"
 
 dependencies:


### PR DESCRIPTION
Fixing "Type 'VideoEmbedParameter' has no member 'showInfo'" error on IOS. I've removed showInfo property from ios/Classes/FlutterYoutubeView.swift as it has been removed from YoutubeKit package.